### PR TITLE
includes go into header instead of translation unit

### DIFF
--- a/internal/clang/emit.go
+++ b/internal/clang/emit.go
@@ -114,9 +114,6 @@ func (g *Generator) emitImpl(w io.Writer) {
 	g.state.writer = w
 
 	fmt.Fprintf(w, "#include \"%s.h\"\n", g.pkg.Name)
-	for _, inc := range g.includes {
-		fmt.Fprintf(w, "#include %s\n", inc)
-	}
 
 	g.emitEmbeds(w, g.embeds.impl)
 	g.emitUnexportedTypes(w)

--- a/internal/clang/header.go
+++ b/internal/clang/header.go
@@ -30,6 +30,9 @@ func (g *Generator) emitImports(w io.Writer) {
 		}
 	}
 	slices.Sort(paths)
+	for _, inc := range g.includes {
+		fmt.Fprintf(w, "#include %s\n", inc)
+	}
 	for _, p := range paths {
 		fmt.Fprintf(w, "#include \"%s\"\n", p)
 	}


### PR DESCRIPTION
This will fix https://github.com/solod-dev/solod/issues/33

The problem:
```go
package net

import (
	"solod.dev/so/errors"
)

//so:include <SDL2/SDL_net.h>

//so:extern TCPsocket
type netTcpSocket *struct{}

// Conn is a TCP client connection.
type Conn struct {
	sock netTcpSocket // does not work because TCPsocket is not included in the generated header.
}
```